### PR TITLE
Updated README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "observable-property"
-version = "0.3.4"
+version = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "observable-property"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 authors = ["Iede Snoek <info@esoxsolutions.nl>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-observable-property = "0.3.2"
+observable-property = "0.3.5"
 ```
 
 ## Usage


### PR DESCRIPTION
This pull request updates the version of the `observable-property` crate from 0.3.4 to 0.3.5 and reflects this change in the documentation. These updates ensure that users and downstream dependencies reference the latest release.

Version update:

* Bumped the crate version in `Cargo.toml` from 0.3.4 to 0.3.5 to prepare a new release.

Documentation update:

* Updated the dependency version in the `README.md` installation instructions to match the new release (0.3.5).